### PR TITLE
added check for variable type before displaying delta

### DIFF
--- a/fixit.py
+++ b/fixit.py
@@ -192,8 +192,10 @@ class MyDisplay(Display):
         if showDeltas: 
           if isinstance(self.currVals[nn],str):
             outtext.append(f"{pv} was {self.histVals[-1]} now = {delta}")
-          else:
+          elif isinstance(delta,int) or isinstance(delta,float):
             outtext.append(f"{pv} was {self.histVals[-1]:.4g} now-then= {delta:.4g}")
+          else:
+            outtext.append(f"{pv} was {self.histVals[-1]:.4g} now-then= {delta}")
         else:
           if isinstance(self.histVals[-1],str):
             outtext.append(f"{pv} was {self.histVals[-1]}")


### PR DESCRIPTION
Pyfixit wasn't writing the differences if the variable type was numpy... so added a check for int/float otherwise rely on variable type's own print.